### PR TITLE
feat: Add delete functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,10 @@ class TodoApp {
         this.prioritySelect = document.getElementById('prioritySelect');
 
         this.darkModeToggle = document.getElementById('darkModeToggle');
+        this.undoToast = document.getElementById('undoToast');
+        this.undoBtn = document.getElementById('undoBtn');
+        this.undoTimeout = null;
+        this.lastDeleted = null;
 
         this.init();
     }
@@ -29,6 +33,7 @@ class TodoApp {
 
         this.clearCompleted.addEventListener('click', () => this.clearCompletedTodos());
         this.darkModeToggle.addEventListener('click', () => this.toggleDarkMode());
+        this.undoBtn.addEventListener('click', () => this.undoDelete());
 
         this.todoList.addEventListener('dragstart', (e) => this.handleDragStart(e));
         this.todoList.addEventListener('dragover', (e) => this.handleDragOver(e));
@@ -87,7 +92,48 @@ class TodoApp {
     }
 
     deleteTodo(id) {
-        this.todos = this.todos.filter(t => t.id !== id);
+        const item = this.todoList.querySelector(`[data-id="${id}"]`);
+        const todo = this.todos.find(t => t.id === id);
+        if (!todo) return;
+
+        const index = this.todos.indexOf(todo);
+        this.lastDeleted = { todo: { ...todo }, index };
+
+        if (item) {
+            item.classList.add('deleting');
+            item.addEventListener('animationend', () => {
+                this.todos = this.todos.filter(t => t.id !== id);
+                this.saveTodos();
+                this.render();
+                this.showUndoToast(todo.text);
+            }, { once: true });
+        } else {
+            this.todos = this.todos.filter(t => t.id !== id);
+            this.saveTodos();
+            this.render();
+            this.showUndoToast(todo.text);
+        }
+    }
+
+    showUndoToast(text) {
+        clearTimeout(this.undoTimeout);
+        const label = text.length > 25 ? text.substring(0, 25) + '...' : text;
+        this.undoToast.querySelector('.undo-text').textContent = `"${label}" deleted`;
+        this.undoToast.classList.add('visible');
+        this.undoTimeout = setTimeout(() => {
+            this.undoToast.classList.remove('visible');
+            this.lastDeleted = null;
+        }, 5000);
+    }
+
+    undoDelete() {
+        if (!this.lastDeleted) return;
+        clearTimeout(this.undoTimeout);
+        this.undoToast.classList.remove('visible');
+
+        const { todo, index } = this.lastDeleted;
+        this.todos.splice(Math.min(index, this.todos.length), 0, todo);
+        this.lastDeleted = null;
         this.saveTodos();
         this.render();
     }

--- a/index.html
+++ b/index.html
@@ -40,6 +40,11 @@
         </div>
     </div>
 
+    <div id="undoToast" class="undo-toast">
+        <span class="undo-text"></span>
+        <button id="undoBtn" class="undo-btn">Undo</button>
+    </div>
+
     <footer class="footer">Built by Claude</footer>
 
     <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -237,11 +237,79 @@ header h1 {
     cursor: pointer;
     padding: 5px 10px;
     border-radius: 8px;
-    transition: background 0.2s;
+    transition: background 0.2s, opacity 0.2s;
+    opacity: 0;
+    flex-shrink: 0;
+}
+
+.todo-item:hover .delete-btn {
+    opacity: 1;
 }
 
 .delete-btn:hover {
     background: #ffe0e0;
+}
+
+/* Always show delete button on touch devices */
+@media (hover: none) {
+    .delete-btn {
+        opacity: 1;
+    }
+}
+
+/* Delete animation */
+@keyframes fadeOut {
+    to {
+        opacity: 0;
+        transform: translateX(20px);
+        height: 0;
+        padding: 0;
+        margin: 0;
+        overflow: hidden;
+    }
+}
+
+.todo-item.deleting {
+    animation: fadeOut 0.3s ease forwards;
+}
+
+/* Undo toast */
+.undo-toast {
+    position: fixed;
+    bottom: 30px;
+    left: 50%;
+    transform: translateX(-50%) translateY(100px);
+    background: #333;
+    color: white;
+    padding: 12px 20px;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    box-shadow: 0 8px 30px rgba(0,0,0,0.3);
+    z-index: 1000;
+    font-size: 0.9rem;
+    transition: transform 0.3s ease;
+}
+
+.undo-toast.visible {
+    transform: translateX(-50%) translateY(0);
+}
+
+.undo-toast .undo-btn {
+    background: none;
+    border: 1px solid rgba(255,255,255,0.3);
+    color: #667eea;
+    font-weight: 600;
+    padding: 4px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: background 0.2s;
+}
+
+.undo-toast .undo-btn:hover {
+    background: rgba(255,255,255,0.1);
 }
 
 .stats {
@@ -416,6 +484,11 @@ body.dark .clear-btn:disabled {
 
 body.dark .delete-btn:hover {
     background: rgba(255, 107, 107, 0.15);
+}
+
+body.dark .undo-toast {
+    background: #2a2a3e;
+    box-shadow: 0 8px 30px rgba(0,0,0,0.5);
 }
 
 body.dark .empty-state {


### PR DESCRIPTION
## Summary
- Animated fadeOut effect when deleting todos (slide right + fade)
- Delete button hidden by default, appears on hover for cleaner UI
- Always visible on touch devices for mobile accessibility
- Undo toast notification appears for 5 seconds after deletion, allowing recovery
- Full dark mode support for all new UI elements

## Test plan
- [ ] Delete a todo item and verify the fadeOut animation plays
- [ ] Hover over a todo to confirm the delete button appears
- [ ] Test on mobile/touch device to verify delete button is always visible
- [ ] Delete a todo and click "Undo" within 5 seconds to restore it
- [ ] Verify undo toast auto-dismisses after 5 seconds
- [ ] Toggle dark mode and verify undo toast styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)