### PR TITLE
feat: Add delete button hover visibility and fade-out animation

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,9 +87,19 @@ class TodoApp {
     }
 
     deleteTodo(id) {
-        this.todos = this.todos.filter(t => t.id !== id);
-        this.saveTodos();
-        this.render();
+        const item = this.todoList.querySelector(`[data-id="${id}"]`);
+        if (item) {
+            item.classList.add('deleting');
+            item.addEventListener('animationend', () => {
+                this.todos = this.todos.filter(t => t.id !== id);
+                this.saveTodos();
+                this.render();
+            }, { once: true });
+        } else {
+            this.todos = this.todos.filter(t => t.id !== id);
+            this.saveTodos();
+            this.render();
+        }
     }
     
     setFilter(filter) {

--- a/style.css
+++ b/style.css
@@ -237,11 +237,37 @@ header h1 {
     cursor: pointer;
     padding: 5px 10px;
     border-radius: 8px;
-    transition: background 0.2s;
+    transition: background 0.2s, opacity 0.2s;
+    opacity: 0;
+}
+
+.todo-item:hover .delete-btn {
+    opacity: 1;
 }
 
 .delete-btn:hover {
     background: #ffe0e0;
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+        transform: translateX(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateX(20px);
+    }
+}
+
+.todo-item.deleting {
+    animation: fadeOut 0.3s ease forwards;
+}
+
+@media (hover: none) {
+    .delete-btn {
+        opacity: 1;
+    }
 }
 
 .stats {


### PR DESCRIPTION
## Summary
- Make delete button visible only on hover to keep the UI clean (always visible on touch/mobile devices via `@media (hover: none)`)
- Add a smooth slide-out fade animation when deleting a todo item
- Delete button was already functional — this PR enhances its UX

## Test plan
- [ ] Hover over a todo item and verify the delete (trash) button appears
- [ ] Click the delete button and verify the todo fades/slides out before being removed
- [ ] Verify the items counter updates after deletion
- [ ] Test on mobile — delete button should always be visible
- [ ] Verify it works alongside priority badges and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)